### PR TITLE
check name.split length before attempting to read its array value in …

### DIFF
--- a/src/components/templates/cards/profile-card/ProfileCard.tsx
+++ b/src/components/templates/cards/profile-card/ProfileCard.tsx
@@ -42,7 +42,7 @@ function stringAvatar(name: string) {
             height: 100,
             width: 100
         },
-        children: `${name.split(' ')[0][0]}${name.split(' ')[1][0]}`
+        children: name.split(' ')?.length > 1 ? `${name.split(' ')[0][0]}${name.split(' ')[1][0]}` : name
     };
 }
 


### PR DESCRIPTION
…case there are no spaces in the OIDC displayName